### PR TITLE
Fix symbol validation for quotes and proper comparison

### DIFF
--- a/Main/src/App.java
+++ b/Main/src/App.java
@@ -59,10 +59,19 @@ public class App {
             String character = Character.toString(symbols.charAt(i));
 
             if (openSymbols.contains(character)) {
-                stackSymbols.push(character);
+                // Handle quotes, where the opening and closing symbol are equal
+                if (dictSymbols.get(character).equals(character)) {
+                    if (!stackSymbols.empty() && stackSymbols.peek().equals(character)) {
+                        stackSymbols.pop();
+                    } else {
+                        stackSymbols.push(character);
+                    }
+                } else {
+                    stackSymbols.push(character);
+                }
             } else if (dictSymbols.containsValue(character)) {
 
-                if (stackSymbols.empty() || dictSymbols.get(stackSymbols.pop()) != character) {
+                if (stackSymbols.empty() || !dictSymbols.get(stackSymbols.pop()).equals(character)) {
                     return false;
                 }
 


### PR DESCRIPTION
## Summary
- handle quotation marks properly in the symbol validator
- use `.equals` when comparing closing symbols

## Testing
- `javac Main/src/App.java`
- `java -cp out App <<EOF
"hello" world
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685a9e469aac83318e4f4fe28c83b759